### PR TITLE
Add support for custom bid InDecrements

### DIFF
--- a/src/main/java/me/badbones69/crazyauctions/Main.java
+++ b/src/main/java/me/badbones69/crazyauctions/Main.java
@@ -3,6 +3,7 @@ package me.badbones69.crazyauctions;
 import me.badbones69.crazyauctions.api.*;
 import me.badbones69.crazyauctions.api.FileManager.Files;
 import me.badbones69.crazyauctions.api.events.AuctionListEvent;
+import me.badbones69.crazyauctions.controllers.ButtonController;
 import me.badbones69.crazyauctions.controllers.GUI;
 import me.badbones69.crazyauctions.controllers.Metrics;
 import me.badbones69.crazyauctions.currency.Vault;
@@ -27,9 +28,11 @@ public class Main extends JavaPlugin implements Listener {
 	
 	public static FileManager fileManager = FileManager.getInstance();
 	public static CrazyAuctions crazyAuctions = CrazyAuctions.getInstance();
+	private static Main instance;
 	
 	@Override
 	public void onEnable() {
+	    instance = this;
 		fileManager.logInfo(true).setup(this);
 		crazyAuctions.loadCrazyAuctions();
 		Bukkit.getServer().getPluginManager().registerEvents(this, this);
@@ -48,6 +51,10 @@ public class Main extends JavaPlugin implements Listener {
 		int file = 0;
 		Bukkit.getScheduler().cancelTask(file);
 		Files.DATA.saveFile();
+	}
+	
+	public static Main getInstance() {
+	    return instance;
 	}
 	
 	public boolean onCommand(CommandSender sender, Command cmd, String commandLable, String[] args) {
@@ -84,6 +91,7 @@ public class Main extends JavaPlugin implements Listener {
 					if(!Methods.hasPermission(sender, "Admin")) return true;
 					fileManager.logInfo(true).setup(this);
 					crazyAuctions.loadCrazyAuctions();
+					ButtonController.getInstance().reload();
 					sender.sendMessage(Messages.RELOAD.getMessage());
 					return true;
 				}
@@ -313,7 +321,7 @@ public class Main extends JavaPlugin implements Listener {
 			@Override
 			public void run() {
 				if(player.getName().equals("BadBones69")) {
-					player.sendMessage(Methods.getPrefix() + Methods.color("&7This server is running your Crazy Auctions Plugin. " + "&7It is running version &av" + Bukkit.getServer().getPluginManager().getPlugin("CrazyAuctions").getDescription().getVersion() + "&7."));
+					player.sendMessage(Methods.getPrefix() + Methods.color("&7This server is running your Crazy Auctions Plugin. " + "&7It is running version &av" + getDescription().getVersion() + "&7."));
 				}
 			}
 		}.runTaskLater(this, 40);

--- a/src/main/java/me/badbones69/crazyauctions/Methods.java
+++ b/src/main/java/me/badbones69/crazyauctions/Methods.java
@@ -19,7 +19,7 @@ import java.util.*;
 
 public class Methods {
 	
-	public static Plugin plugin = Bukkit.getServer().getPluginManager().getPlugin("CrazyAuctions");
+	public static Plugin plugin = Main.getInstance();
 	private static FileManager fileManager = FileManager.getInstance();
 	
 	public static String color(String msg) {

--- a/src/main/java/me/badbones69/crazyauctions/controllers/ButtonController.java
+++ b/src/main/java/me/badbones69/crazyauctions/controllers/ButtonController.java
@@ -1,0 +1,82 @@
+package me.badbones69.crazyauctions.controllers;
+
+import org.bukkit.configuration.file.FileConfiguration;
+
+import me.badbones69.crazyauctions.api.FileManager.Files;
+import me.badbones69.crazyauctions.objects.DeIncrementButton;
+import me.badbones69.crazyauctions.objects.DeIncrementType;
+
+public class ButtonController {
+    
+    private static ButtonController instance;
+    
+    private DeIncrementButton _increment_1;
+    private DeIncrementButton _increment_2;
+    private DeIncrementButton _increment_3;
+    private DeIncrementButton _increment_4;
+    private DeIncrementButton _decrement_1;
+    private DeIncrementButton _decrement_2;
+    private DeIncrementButton _decrement_3;
+    private DeIncrementButton _decrement_4;
+    private FileConfiguration _config;
+
+    public DeIncrementButton getIncrement_1() {
+        return _increment_1;
+    }
+
+    public DeIncrementButton getIncrement_2() {
+        return _increment_2;
+    }
+
+    public DeIncrementButton getIncrement_3() {
+        return _increment_3;
+    }
+
+    public DeIncrementButton getIncrement_4() {
+        return _increment_4;
+    }
+
+    public DeIncrementButton getDecrement_1() {
+        return _decrement_1;
+    }
+
+    public DeIncrementButton getDecrement_2() {
+        return _decrement_2;
+    }
+
+    public DeIncrementButton getDecrement_3() {
+        return _decrement_3;
+    }
+
+    public DeIncrementButton getDecrement_4() {
+        return _decrement_4;
+    }
+
+    public static ButtonController getInstance() {
+        if (instance == null) {
+            instance = new ButtonController();
+        }
+        return instance;
+    }
+
+    public ButtonController() {
+        init();
+    }
+
+    public void reload() {
+        init();
+    }
+
+    private void init() {
+        _config = Files.CONFIG.getFile();
+        _increment_1 = new DeIncrementButton(_config.getString("Settings.Increments.1.Color", "&a"), _config.getString("Settings.Increments.1.Material", ""), _config.getInt("Settings.Increments.1.Amount", 1), DeIncrementType.ADD);
+        _increment_2 = new DeIncrementButton(_config.getString("Settings.Increments.2.Color", "&a"), _config.getString("Settings.Increments.2.Material", ""), _config.getInt("Settings.Increments.2.Amount", 10), DeIncrementType.ADD);
+        _increment_3 = new DeIncrementButton(_config.getString("Settings.Increments.3.Color", "&a"), _config.getString("Settings.Increments.3.Material", ""), _config.getInt("Settings.Increments.3.Amount", 100), DeIncrementType.ADD);
+        _increment_4 = new DeIncrementButton(_config.getString("Settings.Increments.4.Color", "&a"), _config.getString("Settings.Increments.4.Material", ""), _config.getInt("Settings.Increments.4.Amount", 1000), DeIncrementType.ADD);
+        _decrement_1 = new DeIncrementButton(_config.getString("Settings.Decrements.1.Color", "&c"), _config.getString("Settings.Decrements.1.Material", ""), _config.getInt("Settings.Decrements.1.Amount", 1), DeIncrementType.SUBTRACT);
+        _decrement_2 = new DeIncrementButton(_config.getString("Settings.Decrements.2.Color", "&c"), _config.getString("Settings.Decrements.2.Material", ""), _config.getInt("Settings.Decrements.2.Amount", 10), DeIncrementType.SUBTRACT);
+        _decrement_3 = new DeIncrementButton(_config.getString("Settings.Decrements.3.Color", "&c"), _config.getString("Settings.Decrements.3.Material", ""), _config.getInt("Settings.Decrements.3.Amount", 100), DeIncrementType.SUBTRACT);
+        _decrement_4 = new DeIncrementButton(_config.getString("Settings.Decrements.4.Color", "&c"), _config.getString("Settings.Decrements.4.Material", ""), _config.getInt("Settings.Decrements.4.Amount", 1000), DeIncrementType.SUBTRACT);
+    }
+
+}

--- a/src/main/java/me/badbones69/crazyauctions/controllers/GUI.java
+++ b/src/main/java/me/badbones69/crazyauctions/controllers/GUI.java
@@ -1,5 +1,6 @@
 package me.badbones69.crazyauctions.controllers;
 
+import me.badbones69.crazyauctions.Main;
 import me.badbones69.crazyauctions.Methods;
 import me.badbones69.crazyauctions.api.*;
 import me.badbones69.crazyauctions.api.FileManager.Files;
@@ -34,7 +35,7 @@ public class GUI implements Listener {
 	private static HashMap<Player, List<Integer>> List = new HashMap<>();
 	private static HashMap<Player, String> IDs = new HashMap<>();
 	private static CrazyAuctions crazyAuctions = CrazyAuctions.getInstance();
-	private static Plugin plugin = Bukkit.getServer().getPluginManager().getPlugin("CrazyAuctions");
+	private static Plugin plugin = Main.getInstance();
 	
 	public static void openShop(Player player, ShopType sell, Category cat, int page) {
 		Methods.updateAuction();
@@ -311,6 +312,7 @@ public class GUI implements Listener {
 		Methods.updateAuction();
 		FileConfiguration config = Files.CONFIG.getFile();
 		FileConfiguration data = Files.DATA.getFile();
+		ButtonController btnC = ButtonController.getInstance();
 		if(!data.contains("Items." + ID)) {
 			openShop(player, ShopType.BID, shopCategory.get(player), 1);
 			player.sendMessage(Messages.ITEM_DOESNT_EXIST.getMessage());
@@ -318,25 +320,14 @@ public class GUI implements Listener {
 		}
 		Inventory inv = Bukkit.createInventory(null, 27, Methods.color(config.getString("Settings.Bidding-On-Item")));
 		if(!bidding.containsKey(player)) bidding.put(player, 0);
-		if(Version.getCurrentVersion().isNewer(Version.v1_12_R1)) {
-			inv.setItem(9, Methods.makeItem("LIME_STAINED_GLASS_PANE", 1, "&a+1"));
-			inv.setItem(10, Methods.makeItem("LIME_STAINED_GLASS_PANE", 1, "&a+10"));
-			inv.setItem(11, Methods.makeItem("LIME_STAINED_GLASS_PANE", 1, "&a+100"));
-			inv.setItem(12, Methods.makeItem("LIME_STAINED_GLASS_PANE", 1, "&a+1000"));
-			inv.setItem(14, Methods.makeItem("RED_STAINED_GLASS_PANE", 1, "&c-1000"));
-			inv.setItem(15, Methods.makeItem("RED_STAINED_GLASS_PANE", 1, "&c-100"));
-			inv.setItem(16, Methods.makeItem("RED_STAINED_GLASS_PANE", 1, "&c-10"));
-			inv.setItem(17, Methods.makeItem("RED_STAINED_GLASS_PANE", 1, "&c-1"));
-		}else {
-			inv.setItem(9, Methods.makeItem("160:5", 1, "&a+1"));
-			inv.setItem(10, Methods.makeItem("160:5", 1, "&a+10"));
-			inv.setItem(11, Methods.makeItem("160:5", 1, "&a+100"));
-			inv.setItem(12, Methods.makeItem("160:5", 1, "&a+1000"));
-			inv.setItem(14, Methods.makeItem("160:14", 1, "&c-1000"));
-			inv.setItem(15, Methods.makeItem("160:14", 1, "&c-100"));
-			inv.setItem(16, Methods.makeItem("160:14", 1, "&c-10"));
-			inv.setItem(17, Methods.makeItem("160:14", 1, "&c-1"));
-		}
+		inv.setItem(9, Methods.makeItem(btnC.getIncrement_1().getMaterial(), 1, btnC.getIncrement_1().getButtonName()));
+        inv.setItem(10, Methods.makeItem(btnC.getIncrement_2().getMaterial(), 1, btnC.getIncrement_2().getButtonName()));
+        inv.setItem(11, Methods.makeItem(btnC.getIncrement_3().getMaterial(), 1, btnC.getIncrement_3().getButtonName()));
+        inv.setItem(12, Methods.makeItem(btnC.getIncrement_4().getMaterial(), 1, btnC.getIncrement_4().getButtonName()));
+        inv.setItem(14, Methods.makeItem(btnC.getDecrement_1().getMaterial(), 1, btnC.getDecrement_1().getButtonName()));
+        inv.setItem(15, Methods.makeItem(btnC.getDecrement_2().getMaterial(), 1, btnC.getDecrement_2().getButtonName()));
+        inv.setItem(16, Methods.makeItem(btnC.getDecrement_3().getMaterial(), 1, btnC.getDecrement_3().getButtonName()));
+        inv.setItem(17, Methods.makeItem(btnC.getDecrement_4().getMaterial(), 1, btnC.getDecrement_4().getButtonName()));
 		inv.setItem(13, getBiddingGlass(player, ID));
 		inv.setItem(22, Methods.makeItem(config.getString("Settings.GUISettings.OtherSettings.Bid.Item"), 1, config.getString("Settings.GUISettings.OtherSettings.Bid.Name"), config.getStringList("Settings.GUISettings.OtherSettings.Bid.Lore")));
 		
@@ -518,15 +509,16 @@ public class GUI implements Listener {
 									playClick(player);
 									return;
 								}
+								ButtonController btnC = ButtonController.getInstance();
 								HashMap<String, Integer> priceEdits = new HashMap<>();
-								priceEdits.put("&a+1", 1);
-								priceEdits.put("&a+10", 10);
-								priceEdits.put("&a+100", 100);
-								priceEdits.put("&a+1000", 1000);
-								priceEdits.put("&c-1", -1);
-								priceEdits.put("&c-10", -10);
-								priceEdits.put("&c-100", -100);
-								priceEdits.put("&c-1000", -1000);
+								priceEdits.put(btnC.getIncrement_1().getButtonName(), btnC.getIncrement_1().getValue());
+								priceEdits.put(btnC.getIncrement_2().getButtonName(), btnC.getIncrement_2().getValue());
+								priceEdits.put(btnC.getIncrement_3().getButtonName(), btnC.getIncrement_3().getValue());
+								priceEdits.put(btnC.getIncrement_4().getButtonName(), btnC.getIncrement_4().getValue());
+								priceEdits.put(btnC.getDecrement_1().getButtonName(), btnC.getDecrement_1().getValue());
+								priceEdits.put(btnC.getDecrement_2().getButtonName(), btnC.getDecrement_2().getValue());
+								priceEdits.put(btnC.getDecrement_3().getButtonName(), btnC.getDecrement_3().getValue());
+								priceEdits.put(btnC.getDecrement_4().getButtonName(), btnC.getDecrement_4().getValue());
 								for(String price : priceEdits.keySet()) {
 									if(item.getItemMeta().getDisplayName().equals(Methods.color(price))) {
 										try {

--- a/src/main/java/me/badbones69/crazyauctions/objects/Button.java
+++ b/src/main/java/me/badbones69/crazyauctions/objects/Button.java
@@ -1,0 +1,21 @@
+package me.badbones69.crazyauctions.objects;
+
+public class Button {
+
+    private String _displayName;
+    private String _material;
+
+    public Button(String displayName, String material) {
+        _displayName = displayName;
+        _material = material;
+    }
+
+    public String getButtonName() {
+        return _displayName;
+    }
+
+    public String getMaterial() {
+        return _material;
+    }
+
+}

--- a/src/main/java/me/badbones69/crazyauctions/objects/DeIncrementButton.java
+++ b/src/main/java/me/badbones69/crazyauctions/objects/DeIncrementButton.java
@@ -1,0 +1,27 @@
+package me.badbones69.crazyauctions.objects;
+
+public class DeIncrementButton extends Button {
+
+    private final int _value;
+    private final DeIncrementType _type;
+
+    public DeIncrementButton(String displayName, String material, int value, DeIncrementType type) {
+        super(displayName, material);
+        _value = value;
+        _type = type;
+        
+    }
+
+    @Override
+    public String getButtonName() {
+        return super.getButtonName() + _type.getSign() + _value;
+    }
+
+    public int getValue() {
+        if(_type == DeIncrementType.SUBTRACT) {
+            return -_value;
+        }
+        return _value;
+    }
+
+}

--- a/src/main/java/me/badbones69/crazyauctions/objects/DeIncrementType.java
+++ b/src/main/java/me/badbones69/crazyauctions/objects/DeIncrementType.java
@@ -1,0 +1,18 @@
+package me.badbones69.crazyauctions.objects;
+
+public enum DeIncrementType {
+
+    ADD("+"),
+    SUBTRACT("-");
+
+    private DeIncrementType(String sign) {
+        _sign = sign;
+    }
+
+    private final String _sign;
+
+    public String getSign() {
+        return _sign;
+    }
+
+}

--- a/src/main/resources/config1.12.2-Down.yml
+++ b/src/main/resources/config1.12.2-Down.yml
@@ -16,6 +16,40 @@ Settings:
   Max-Beginning-Bid-Price: 1000000 #Maximum starting bid.
   Allow-Damaged-Items: False #Allow items that have been damaged.
   Category-Page-Opens-First: False #If set to true the categories page will open when they do /CA.
+  Increments:
+    1:
+      Amount: 1
+      Color: '&a'
+      Material: '160:5'
+    2:
+      Amount: 10
+      Color: '&a'
+      Material: '160:5'
+    3:
+      Amount: 100
+      Color: '&a'
+      Material: '160:5'
+    4:
+      Amount: 1000
+      Color: '&a'
+      Material: '160:5'
+  Decrements:
+    1:
+      Amount: 1
+      Color: '&c'
+      Material: '160:14'
+    2:
+      Amount: 10
+      Color: '&c'
+      Material: '160:14'
+    3:
+      Amount: 100
+      Color: '&c'
+      Material: '160:14'
+    4:
+      Amount: 1000
+      Color: '&c'
+      Material: '160:14'
   Feature-Toggle: #Toggle if a feature is on or off.
     Selling: true #Able to use the selling part of the auction house.
     Bidding: true #Able to use the bidding part of the auction house.

--- a/src/main/resources/config1.13-Up.yml
+++ b/src/main/resources/config1.13-Up.yml
@@ -16,6 +16,40 @@ Settings:
   Max-Beginning-Bid-Price: 1000000 #Maximum starting bid.
   Allow-Damaged-Items: False #Allow items that have been damaged.
   Category-Page-Opens-First: False #If set to true the categories page will open when they do /CA.
+  Increments:
+    1:
+      Amount: 1
+      Color: '&a'
+      Material: 'LIME_STAINED_GLASS_PANE'
+    2:
+      Amount: 10
+      Color: '&a'
+      Material: LIME_STAINED_GLASS_PANE'
+    3:
+      Amount: 100
+      Color: '&a'
+      Material: 'LIME_STAINED_GLASS_PANE'
+    4:
+      Amount: 1000
+      Color: '&a'
+      Material: 'LIME_STAINED_GLASS_PANE'
+  Decrements:
+    1:
+      Amount: 1
+      Color: '&c'
+      Material: 'RED_STAINED_GLASS_PANE'
+    2:
+      Amount: 10
+      Color: '&c'
+      Material: 'RED_STAINED_GLASS_PANE'
+    3:
+      Amount: 100
+      Color: '&c'
+      Material: 'RED_STAINED_GLASS_PANE'
+    4:
+      Amount: 1000
+      Color: '&c'
+      Material: 'RED_STAINED_GLASS_PANE'
   Feature-Toggle: #Toggle if a feature is on or off.
     Selling: true #Able to use the selling part of the auction house.
     Bidding: true #Able to use the bidding part of the auction house.


### PR DESCRIPTION
This adds reloadable support for customizable bid InDecrements

The following can be customized:
- increment value
- increment button material per increment step
- increment button color per increment step

To doesn't produce any errors without a config reset on old installs, but the material will be terracotta.
Tested on 1.14.1 but should work on any other version currently supported.
It's pretty much static, as each button has a field, but still better than before. Could have make it more abstract but I thinks it fine this way

I also changed your string based Plugin getting to get it by a method, because that hurts too much otherwise <3